### PR TITLE
Introduce minimal SwiftUI entry point

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -34,7 +34,6 @@ extension AppDelegate
     static let exportCertificateCallbackTemplateKey = "callback"
 }
 
-@UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -162,8 +162,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
@@ -178,8 +176,6 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/AltStore/SwiftUI/HomeView.swift
+++ b/AltStore/SwiftUI/HomeView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct HomeView: View {
+    private enum Tab: Hashable {
+        case news, sources, browse, myApps, settings
+    }
+
+    @State private var selectedTab: Tab = .news
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            Text("News")
+                .tabItem { Label("News", systemImage: "newspaper") }
+                .tag(Tab.news)
+
+            Text("Sources")
+                .tabItem { Label("Sources", systemImage: "tray.full") }
+                .tag(Tab.sources)
+
+            Text("Browse")
+                .tabItem { Label("Browse", systemImage: "bag") }
+                .tag(Tab.browse)
+
+            Text("My Apps")
+                .tabItem { Label("My Apps", systemImage: "apps.iphone") }
+                .tag(Tab.myApps)
+
+            Text("Settings")
+                .tabItem { Label("Settings", systemImage: "gear") }
+                .tag(Tab.settings)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppDelegate.openPatreonSettingsDeepLinkNotification)) { _ in
+            selectedTab = .settings
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppDelegate.importAppDeepLinkNotification)) { _ in
+            selectedTab = .myApps
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppDelegate.addSourceDeepLinkNotification)) { _ in
+            selectedTab = .sources
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppDelegate.exportCertificateNotification)) { _ in
+            selectedTab = .settings
+        }
+        .onReceive(NotificationCenter.default.publisher(for: ToastView.openErrorLogNotification)) { _ in
+            selectedTab = .settings
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/AltStore/SwiftUI/SideStoreApp.swift
+++ b/AltStore/SwiftUI/SideStoreApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct SideStoreApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            HomeView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- start migrating UI by adding a SwiftUI app entry
- add a simple `HomeView` using `TabView`
- adjust `AppDelegate` to remove the `@UIApplicationMain` attribute
- remove storyboard from Info.plist and handle deep link notifications in `HomeView`

## Testing
- `make test` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb4673d8832d80e8d682749c30b1